### PR TITLE
chore: configure lint tests and e2e

### DIFF
--- a/e2e/app.spec.js
+++ b/e2e/app.spec.js
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const indexPath = path.resolve(__dirname, '..', 'index.html');
+
+test('home page title and script path', async ({ page }) => {
+  await page.goto('file://' + indexPath);
+  await expect(page).toHaveTitle('CST SmartDesk — Escalation Toolkit');
+  const scriptSrc = await page.getAttribute('script[src]', 'src');
+  expect(scriptSrc).toBe('/app.js');
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,25 @@
+import js from "@eslint/js";
+import globals from "globals";
+
+export default [
+  {
+    ignores: ["node_modules", "dist", ".vercel", "playwright-report", "test-results"],
+  },
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+  },
+  js.configs.recommended,
+  {
+    rules: {
+      "no-undef": "error",
+      "no-implied-eval": "error",
+      "no-alert": "error"
+    }
+  }
+];

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "greeting": "Hello",
+  "farewell": "Goodbye"
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,4 @@
+{
+  "greeting": "Hola",
+  "farewell": "Adiós"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "cst-smartdeskapp",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "lint": "eslint .",
+    "test": "vitest run",
+    "e2e": "playwright test",
+    "postinstall": "playwright install --with-deps"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "@playwright/test": "^1.45.0",
+    "eslint": "^9.0.0",
+    "globals": "^15.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e'
+});

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test, expect } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadLocale(name) {
+  const file = path.join(__dirname, '..', 'locales', `${name}.json`);
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+test('locales have same keys', () => {
+  const en = loadLocale('en');
+  const es = loadLocale('es');
+  expect(Object.keys(es).sort()).toEqual(Object.keys(en).sort());
+});


### PR DESCRIPTION
## Summary
- add ESLint 9 flat config and lint rules
- set up Vitest locale test and Playwright e2e spec
- wire npm scripts with Playwright postinstall

## Testing
- `npm install --no-audit --no-fund --registry=https://registry.npmjs.org` (fails: 403 Forbidden)
- `npm run lint` (fails: cannot find `@eslint/js`)
- `npm test` (fails: `vitest` not found)
- `npm run e2e` (fails: `playwright` not found)


------
https://chatgpt.com/codex/tasks/task_e_689bd2723f048326910d0ab5cd7e6abb