### PR TITLE
build: skip dev deps on Vercel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "cst-smartdeskapp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cst-smartdeskapp",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cst-smartdeskapp",
+  "version": "1.0.0",
+  "description": "**Single clean deploy rules:** - `index.html` at repo root - Client JS at `/public/app.js` (referenced as `<script src=\"/app.js\" defer>`) - Logos in `/public/assets` - Serverless endpoints in `/api` (Node on Vercel)",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "private": true
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,15 +3,33 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "Referrer-Policy", "value": "no-referrer" },
-        { "key": "Permissions-Policy", "value": "clipboard-read=(self), clipboard-write=(self)" },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "clipboard-read=(self), clipboard-write=(self)"
+        },
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://www.asurion.com; base-uri 'none'; frame-ancestors 'none'; form-action 'self';"
         }
       ]
     }
-  ]
+  ],
+  "installCommand": "npm ci --omit=dev",
+  "functions": {
+    "api/**": {
+      "runtime": "nodejs20.x"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- remove postinstall script and add minimal package manifest
- run Vercel installs with `npm ci --omit=dev`
- target Node.js 20 for API routes

## Testing
- `npm ci --omit=dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bdd47e75c832690883e0a6aa435d0