### PR TITLE
chore(vercel): preview stabilized

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "npm ci --omit=dev",
   "headers": [
     {
       "source": "/(.*)",
@@ -6,12 +7,19 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "no-referrer" },
-        { "key": "Permissions-Policy", "value": "clipboard-read=(self), clipboard-write=(self)" },
+        {
+          "key": "Permissions-Policy",
+          "value": "clipboard-read=(self), clipboard-write=(self)"
+        },
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://www.asurion.com; base-uri 'none'; frame-ancestors 'none'; form-action 'self';"
         }
       ]
     }
+  ],
+  "rewrites": [
+    { "source": "/app.js", "destination": "/public/app.js" },
+    { "source": "/utils/:path*", "destination": "/public/utils/:path*" }
   ]
 }


### PR DESCRIPTION
## Summary
- add install command for lean Vercel installs
- configure rewrites for app bundle and utils paths

## Testing
- `./setup.sh` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c17d348c48326893094527719efbd