### PR TITLE
test: cover fetch host allowlist

### DIFF
--- a/api/__tests__/enqueue.test.js
+++ b/api/__tests__/enqueue.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
+import { test, expect } from 'vitest';
 import handler from '../enqueue.js';
 
 function createMockRes() {
@@ -21,14 +20,14 @@ test('GET returns 405 with { ok:false }', async () => {
   const req = { method: 'GET' };
   const res = createMockRes();
   await handler(req, res);
-  assert.equal(res.statusCode, 405);
-  assert.deepEqual(res.body, { ok: false, error: 'Method not allowed' });
+  expect(res.statusCode).toBe(405);
+  expect(res.body).toEqual({ ok: false, error: 'Method not allowed' });
 });
 
 test('POST returns 200 with { ok:true, queued:true }', async () => {
   const req = { method: 'POST' };
   const res = createMockRes();
   await handler(req, res);
-  assert.equal(res.statusCode, 200);
-  assert.deepEqual(res.body, { ok: true, queued: true });
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ ok: true, queued: true });
 });

--- a/api/enqueue.js
+++ b/api/enqueue.js
@@ -1,0 +1,8 @@
+// Vercel Serverless Function: POST /api/enqueue
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ ok: false, error: 'Method not allowed' });
+    return;
+  }
+  res.status(200).json({ ok: true, queued: true });
+}

--- a/api/fetch.js
+++ b/api/fetch.js
@@ -1,7 +1,28 @@
 // Vercel Serverless Function: GET /api/fetch
 export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
   if (req.method !== 'GET') {
-    res.status(405).json({ error: 'Method not allowed' });
+    res.status(405).json({ ok: false, error: 'Method not allowed' });
+    return;
+  }
+
+  // allow proxying only to a curated list of hosts
+  const { searchParams } = new URL(req.url || '', 'http://local');
+  const target = searchParams.get('url');
+  if (target) {
+    try {
+      const u = new URL(target);
+      const allowed = (process.env.FETCH_ALLOW_HOSTS || '').split(',').filter(Boolean);
+      if (allowed.length && !allowed.includes(u.host)) {
+        res.status(403).json({ ok: false, error: 'Host not allowed' });
+        return;
+      }
+      const r = await fetch(u.href);
+      const text = await r.text();
+      res.status(200).json({ ok: true, body: text });
+    } catch (e) {
+      res.status(400).json({ ok: false, error: e.message });
+    }
     return;
   }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from '@playwright/test';
 export default defineConfig({
+  testDir: 'e2e',
+  testMatch: /.*\.spec\.[jt]s$/,
   webServer: {
     command: 'npm run serve',
     port: 4173,

--- a/public/app.js
+++ b/public/app.js
@@ -57,7 +57,7 @@ async function toggleLang() {
 }
 
 // --- Setup Wizard ---
-function onSaveWizard(ev) {
+function onSaveWizard() {
   // dialog value is "save"
   const s = {
     name: val('#wName'),

--- a/tests/fetch.test.js
+++ b/tests/fetch.test.js
@@ -1,0 +1,57 @@
+import { test, expect, afterAll } from 'vitest';
+import handler from '../api/fetch.js';
+
+function mockRes() {
+  return {
+    statusCode: 0,
+    headers: {},
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    setHeader(k, v) {
+      this.headers[k.toLowerCase()] = v;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+const originalFetch = global.fetch;
+
+test('allowed host returns ok true with CORS header', async () => {
+  process.env.FETCH_ALLOW_HOSTS = 'allowed.com';
+  global.fetch = async () => ({ ok: true, text: async () => 'data' });
+  const req = { method: 'GET', url: '/api/fetch?url=https://allowed.com/x' };
+  const res = mockRes();
+  await handler(req, res);
+  expect(res.statusCode).toBe(200);
+  expect(res.body.ok).toBe(true);
+  expect(res.headers['access-control-allow-origin']).toBe('*');
+});
+
+test('disallowed host returns ok false with CORS header', async () => {
+  process.env.FETCH_ALLOW_HOSTS = 'allowed.com';
+  const req = { method: 'GET', url: '/api/fetch?url=https://bad.com/x' };
+  const res = mockRes();
+  await handler(req, res);
+  expect(res.statusCode).toBe(403);
+  expect(res.body.ok).toBe(false);
+  expect(res.headers['access-control-allow-origin']).toBe('*');
+});
+
+test('malformed URL returns ok false with CORS header', async () => {
+  const req = { method: 'GET', url: '/api/fetch?url=::://bad' };
+  const res = mockRes();
+  await handler(req, res);
+  expect(res.statusCode).toBe(400);
+  expect(res.body.ok).toBe(false);
+  expect(res.headers['access-control-allow-origin']).toBe('*');
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'vitest/config';
 export default defineConfig({
-  test: { environment: 'node' }
+  test: {
+    environment: 'node',
+    exclude: ['node_modules/**', 'e2e/**']
+  }
 });


### PR DESCRIPTION
## Summary
- guard `/api/fetch` with CORS and host allowlist support
- add enqueue stub and tests for fetch proxy host validation

## Checks
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1129/chrome-linux/chrome)*


------
https://chatgpt.com/codex/tasks/task_e_689c35cdb0ac8326bd8ff39b99cc3c88