### PR TITLE
chore(merge): resolve binary conflicts

### DIFF
--- a/api/__tests__/enqueue.test.js
+++ b/api/__tests__/enqueue.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
+import { test, expect } from 'vitest';
 import handler from '../enqueue.js';
 
 function createMockRes() {
@@ -21,14 +20,14 @@ test('GET returns 405 with { ok:false }', async () => {
   const req = { method: 'GET' };
   const res = createMockRes();
   await handler(req, res);
-  assert.equal(res.statusCode, 405);
-  assert.deepEqual(res.body, { ok: false, error: 'Method not allowed' });
+  expect(res.statusCode).toBe(405);
+  expect(res.body).toEqual({ ok: false, error: 'Method not allowed' });
 });
 
 test('POST returns 200 with { ok:true, queued:true }', async () => {
   const req = { method: 'POST' };
   const res = createMockRes();
   await handler(req, res);
-  assert.equal(res.statusCode, 200);
-  assert.deepEqual(res.body, { ok: true, queued: true });
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual({ ok: true, queued: true });
 });

--- a/api/enqueue.js
+++ b/api/enqueue.js
@@ -1,0 +1,6 @@
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, error: 'Method not allowed' });
+  }
+  return res.status(200).json({ ok: true, queued: true });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,8 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, defaultExclude } from 'vitest/config';
+
 export default defineConfig({
-  test: { environment: 'node' }
+  test: {
+    environment: 'node',
+    exclude: [...defaultExclude, 'e2e/**']
+  }
 });


### PR DESCRIPTION
## Summary
- exclude e2e specs from Vitest to avoid running Playwright tests in unit suite
- add missing enqueue API and convert its tests to Vitest

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e` *(fails: TypeError: Cannot redefine property: Symbol($$jest-matchers-object))*

## Security/CSP
- No external scripts added; CSP behavior unchanged

## i18n
- No user-facing strings added

## Verification Log
- `npm run lint`
- `npm run test`
- `npm run e2e` *(fails: TypeError: Cannot redefine property: Symbol($$jest-matchers-object))*

------
https://chatgpt.com/codex/tasks/task_e_689c3855ceec8326ab12810004de305b