### PR TITLE
chore: canonicalize playwright config

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,0 @@
-import { defineConfig } from '@playwright/test';
-
-export default defineConfig({
-  testDir: './e2e'
-});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from '@playwright/test';
+
 export default defineConfig({
+  testDir: './e2e',
   webServer: {
     command: 'npm run serve',
     port: 4173,


### PR DESCRIPTION
## Summary
- drop legacy `playwright.config.js`
- ensure Playwright uses `./e2e` directory via TypeScript config

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1129/chrome-linux/chrome)*

## Security/CSP
- No external scripts or CSP issues introduced

## i18n
- n/a

## Verification Log
- `npm run lint`
- `npm run test`
- `npm run e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1129/chrome-linux/chrome)*


------
https://chatgpt.com/codex/tasks/task_e_689c4072218c832696fb6090f9433493