### PR TITLE
chore: install chromium for playwright

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 npm ci || npm i
-npx playwright install --with-deps || true
+npx playwright install chromium --with-deps


### PR DESCRIPTION
## Summary
- ensure setup installs only Playwright Chromium deps
- surface Playwright install errors in setup

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e` *(fails: TypeError: Cannot redefine property: Symbol($$jest-matchers-object))*

## Security/CSP
- no external scripts added; CSP remains unchanged

## i18n
- no user-facing strings added

## Verification Log
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run e2e`
- `npm run serve` & curl `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`


------
https://chatgpt.com/codex/tasks/task_e_689c407126e0832689ec91ab1e5e3abf