### PR TITLE
feat(copilot): UI panel + prompt library (EN/ES output)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 - Bilingual scaffolding: `/i18n/en.json`, `/i18n/es.json`
 - Serverless: `GET /api/fetch`, `POST /api/copilot`
 
+## Copilot panel
+
+- Prompts combine a selected sample, free-form text, and optional `CONTEXT_JSON` from the preview panel.
+- Samples live in `/public/copilot-prompts.json`; add new entries with `{ id, label, prompt }`.
+- Requires server-side `OPENAI_API_KEY`; when missing, the UI stays visible and hints about the key.
+
 ## Dev
 ```bash
 npm i

--- a/e2e/copilot.spec.js
+++ b/e2e/copilot.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+const url = 'http://localhost:4173/index.html';
+
+test('copilot generates and copies', async ({ page }) => {
+  await page.route('**/api/copilot', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ en: 'OK EN', es: 'OK ES' }) });
+  });
+  await page.goto(url);
+  await page.selectOption('#copilotSample', { index: 0 });
+  await page.fill('#copilotInput', 'hi');
+  await page.click('#copilotRun');
+  await expect(page.locator('#copilotEn')).toHaveText('OK EN');
+  await expect(page.locator('#copilotEs')).toHaveText('OK ES');
+  await page.click('#copilotCopyEn');
+  const clipEn = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipEn).toBe('OK EN');
+  await page.click('#copilotCopyEs');
+  const clipEs = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipEs).toBe('OK ES');
+});

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2,5 +2,16 @@
   "Drop PDF/TXT here or paste text (Ctrl+V).": "Drop PDF/TXT here or paste text (Ctrl+V).",
   "System Status": "System Status",
   "First-Run Setup": "First-Run Setup",
-  "Tests": "Tests"
+  "Tests": "Tests",
+  "Copilot": "Copilot",
+  "Sample prompt": "Sample prompt",
+  "Additional instructions": "Additional instructions",
+  "Generate": "Generate",
+  "English": "English",
+  "Spanish": "Spanish",
+  "Copy EN": "Copy EN",
+  "Copy ES": "Copy ES",
+  "Loading...": "Loading...",
+  "Set OPENAI_API_KEY in Vercel to enable Copilot.": "Set OPENAI_API_KEY in Vercel to enable Copilot.",
+  "Copilot reachable": "Copilot reachable"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -2,5 +2,16 @@
   "Drop PDF/TXT here or paste text (Ctrl+V).": "Suelta PDF/TXT aquí o pega texto (Ctrl+V).",
   "System Status": "Estado del sistema",
   "First-Run Setup": "Configuración inicial",
-  "Tests": "Pruebas"
+  "Tests": "Pruebas",
+  "Copilot": "Copiloto",
+  "Sample prompt": "Ejemplo de prompt",
+  "Additional instructions": "Instrucciones adicionales",
+  "Generate": "Generar",
+  "English": "Inglés",
+  "Spanish": "Español",
+  "Copy EN": "Copiar EN",
+  "Copy ES": "Copiar ES",
+  "Loading...": "Cargando...",
+  "Set OPENAI_API_KEY in Vercel to enable Copilot.": "Configure OPENAI_API_KEY en Vercel para habilitar Copilot.",
+  "Copilot reachable": "Copilot alcanzable"
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from '@playwright/test';
 export default defineConfig({
+  testDir: './e2e',
   webServer: {
     command: 'npm run serve',
     port: 4173,
     timeout: 60_000,
-    reuseExistingServer: !process.env.CI
+    reuseExistingServer: !process.env.CI,
   },
-  use: { headless: true }
+  use: { headless: true },
 });

--- a/public/app.js
+++ b/public/app.js
@@ -1,10 +1,14 @@
 import { createI18n } from '/utils/i18n.js';
+import { buildPrompt } from '/utils/copilot.js';
 
 const state = {
   settings: null,
   i18n: null,
   cspViolations: [],
   lastFetchRun: null,
+  copilotSamples: [],
+  copilotReachable: null,
+  lang: 'en',
 };
 
 // --- Init ---
@@ -12,6 +16,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // language
   const lang = localStorage.getItem('lang') || 'en';
   state.i18n = await createI18n(lang);
+  state.lang = lang;
   document.getElementById('langToggle').addEventListener('click', toggleLang);
 
   // setup wizard
@@ -28,6 +33,16 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('openTests').addEventListener('click', () => testsModal.showModal());
   document.getElementById('testsClose').addEventListener('click', () => testsModal.close());
   document.getElementById('testsFetchBtn').addEventListener('click', runFetchTest);
+
+  // copilot setup
+  try {
+    state.copilotSamples = await fetch('/copilot-prompts.json').then((r) => r.json());
+  } catch {
+    state.copilotSamples = [];
+  }
+  initCopilot();
+  renderCopilotUI();
+  checkCopilot();
 
   // drag & drop / paste
   const dz = document.getElementById('dropzone');
@@ -56,6 +71,8 @@ async function toggleLang() {
   const next = current === 'en' ? 'es' : 'en';
   localStorage.setItem('lang', next);
   state.i18n = await createI18n(next);
+  state.lang = next;
+  renderCopilotUI();
   renderStatus();
 }
 
@@ -150,6 +167,115 @@ function findSection(text, rx) {
   return text.slice(idx, idx + 240);
 }
 
+// --- Copilot ---
+function initCopilot() {
+  const main = document.querySelector('main.content');
+  const sec = document.createElement('section');
+  sec.id = 'copilotSection';
+  sec.innerHTML = `
+    <h2 id="copilotTitle"></h2>
+    <label><span id="copilotSampleLabel"></span><select id="copilotSample"></select></label>
+    <label><span id="copilotInputLabel"></span><textarea id="copilotInput"></textarea></label>
+    <button id="copilotRun"></button>
+    <div id="copilotOutput" style="display:flex;gap:1rem">
+      <div style="flex:1">
+        <h3 id="copilotEnLabel"></h3>
+        <pre id="copilotEn" class="preview"></pre>
+        <button id="copilotCopyEn"></button>
+      </div>
+      <div style="flex:1">
+        <h3 id="copilotEsLabel"></h3>
+        <pre id="copilotEs" class="preview"></pre>
+        <button id="copilotCopyEs"></button>
+      </div>
+    </div>
+    <p id="copilotMsg" class="warn" hidden></p>
+  `;
+  main.insertBefore(sec, document.getElementById('systemStatus'));
+  document.getElementById('copilotRun').addEventListener('click', onCopilotRun);
+  document
+    .getElementById('copilotCopyEn')
+    .addEventListener('click', () => copyText('copilotEn'));
+  document
+    .getElementById('copilotCopyEs')
+    .addEventListener('click', () => copyText('copilotEs'));
+}
+function renderCopilotUI() {
+  if (!document.getElementById('copilotSection')) return;
+  const t = (s) => state.i18n.t(s);
+  document.getElementById('copilotTitle').textContent = t('Copilot');
+  document.getElementById('copilotSampleLabel').textContent = t('Sample prompt');
+  document.getElementById('copilotInputLabel').textContent = t('Additional instructions');
+  document.getElementById('copilotRun').textContent = t('Generate');
+  document.getElementById('copilotEnLabel').textContent = t('English');
+  document.getElementById('copilotEsLabel').textContent = t('Spanish');
+  document.getElementById('copilotCopyEn').textContent = t('Copy EN');
+  document.getElementById('copilotCopyEs').textContent = t('Copy ES');
+  const sel = document.getElementById('copilotSample');
+  sel.innerHTML = '';
+  state.copilotSamples.forEach((p) => {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    opt.textContent = p.label[state.lang] || p.label.en;
+    sel.appendChild(opt);
+  });
+}
+async function onCopilotRun() {
+  const sel = document.getElementById('copilotSample');
+  const sample = state.copilotSamples.find((p) => p.id === sel.value);
+  const user = document.getElementById('copilotInput').value;
+  let context = null;
+  try {
+    const txt = document.getElementById('preview').textContent;
+    if (txt) context = JSON.parse(txt);
+  } catch {
+    /* noop */
+  }
+  const prompt = buildPrompt(sample?.prompt || '', user, context);
+  const outEn = document.getElementById('copilotEn');
+  const outEs = document.getElementById('copilotEs');
+  const msg = document.getElementById('copilotMsg');
+  outEn.textContent = outEs.textContent = '';
+  msg.textContent = state.i18n.t('Loading...');
+  msg.hidden = false;
+  try {
+    const res = await fetch('/api/copilot', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error();
+    outEn.textContent = data.en || '';
+    outEs.textContent = data.es || '';
+    msg.hidden = true;
+  } catch {
+    msg.textContent = state.i18n.t('Set OPENAI_API_KEY in Vercel to enable Copilot.');
+  }
+  await checkCopilot();
+}
+async function copyText(id) {
+  try {
+    await navigator.clipboard.writeText(document.getElementById(id).textContent);
+  } catch {
+    /* noop */
+  }
+}
+async function checkCopilot() {
+  try {
+    const r = await fetch('/api/copilot', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'ping' }),
+    });
+    await r.json();
+    state.copilotReachable = true;
+  } catch {
+    state.copilotReachable = false;
+  }
+  renderStatus();
+}
+
 // --- System Status ---
 async function run4PointUrlTest() {
   const list = ['/app.js', '/assets/logo.svg', '/api/fetch'];
@@ -214,6 +340,16 @@ function renderStatus() {
       !!(state.settings && state.settings.name),
     ),
   );
+
+  if (state.copilotReachable !== null) {
+    items.push(
+      mark(
+        state.i18n.t('Copilot reachable'),
+        state.copilotReachable ? 'OK' : 'Fail',
+        state.copilotReachable,
+      ),
+    );
+  }
 
   document.getElementById('statusList').innerHTML = items
     .map(

--- a/public/copilot-prompts.json
+++ b/public/copilot-prompts.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "escalation-billing",
+    "label": { "en": "Escalation script (billing dispute)", "es": "Guion de escalacion (disputa de facturacion)" },
+    "prompt": "Agent is handling a billing dispute. Provide a professional escalation script in English and Spanish."
+  },
+  {
+    "id": "imei-troubleshoot",
+    "label": { "en": "Troubleshooting IMEI capture", "es": "Resolucion de problemas de captura de IMEI" },
+    "prompt": "Give step-by-step instructions to capture a device IMEI. Respond in English and Spanish."
+  },
+  {
+    "id": "tc-summarizer",
+    "label": { "en": "T&C summarizer", "es": "Resumidor de TyC" },
+    "prompt": "Summarize provided terms and conditions JSON into key bullet points. Output English and Spanish."
+  },
+  {
+    "id": "deescalation-call",
+    "label": { "en": "De-escalation call open/close", "es": "Apertura/cierre de llamada de desescalacion" },
+    "prompt": "Provide calm opening and closing statements for a customer call. Output English and Spanish."
+  },
+  {
+    "id": "sms-followup",
+    "label": { "en": "Short bilingual SMS follow-up", "es": "Breve seguimiento por SMS bilingue" },
+    "prompt": "Draft a short follow-up SMS template in both English and Spanish."
+  }
+]

--- a/public/utils/copilot.js
+++ b/public/utils/copilot.js
@@ -1,0 +1,10 @@
+export function buildPrompt(samplePrompt = '', userText = '', contextObj = null) {
+  let parts = [];
+  if (contextObj) {
+    let ctx = typeof contextObj === 'string' ? contextObj : JSON.stringify(contextObj);
+    parts.push('CONTEXT_JSON=' + ctx.slice(0, 3000));
+  }
+  if (samplePrompt) parts.push(samplePrompt.trim());
+  if (userText) parts.push(userText.trim());
+  return parts.join('\n\n').trim();
+}

--- a/tests/copilot-prompt.test.js
+++ b/tests/copilot-prompt.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { buildPrompt } from '../public/utils/copilot.js';
+
+describe('buildPrompt', () => {
+  it('merges sample and user text', () => {
+    const p = buildPrompt('sample', 'user');
+    expect(p).toBe('sample\n\nuser');
+  });
+  it('prepends context JSON', () => {
+    const ctx = { a: 1 };
+    const p = buildPrompt('sample', 'user', ctx);
+    expect(p.startsWith('CONTEXT_JSON=')).toBe(true);
+    expect(p.includes('sample')).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from 'vitest/config';
 export default defineConfig({
-  test: { environment: 'node' }
+  test: { environment: 'node', include: ['tests/**/*.test.js'] }
 });


### PR DESCRIPTION
## Summary
- add copilot panel with sample prompts, bilingual output, and copy buttons
- provide prompt builder utility with unit and e2e coverage
- document copilot usage and add i18n strings

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e` *(fails: missing Playwright browsers)*

## Security/CSP
- no external scripts or CSP changes

## i18n
- `Copilot`, `Sample prompt`, `Additional instructions`, `Generate`, `English`, `Spanish`, `Copy EN`, `Copy ES`, `Loading...`, `Set OPENAI_API_KEY in Vercel to enable Copilot.`, `Copilot reachable`

## Verification Log
- `npm run lint`
- `npm run test`
- `npm run e2e` *(fails: missing Playwright browsers)*


------
https://chatgpt.com/codex/tasks/task_e_689c3793ad548326b968cf56c10032cf