### PR TITLE
fix(vercel): serve index at root + keep asset rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "installCommand": "npm ci --omit=dev",
+  "rewrites": [
+    { "source": "/", "destination": "/index.html" },
+    { "source": "/app.js", "destination": "/public/app.js" },
+    { "source": "/utils/:path*", "destination": "/public/utils/:path*" }
+  ],
   "headers": [
     {
       "source": "/(.*)",
@@ -18,9 +23,5 @@
         }
       ]
     }
-  ],
-  "rewrites": [
-    { "source": "/app.js", "destination": "/public/app.js" },
-    { "source": "/utils/:path*", "destination": "/public/utils/:path*" }
   ]
 }


### PR DESCRIPTION
## Summary
- add root rewrite so `/` serves `index.html`
- retain rewrites for `/app.js` and `/utils/*`

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex`

## Security/CSP
- CSP headers unchanged; no external scripts added

## i18n
- n/a

## Verification
- `npm run lint`
- `npm run test`
- `npm run e2e:codex`
- `npm run serve` *(local smoke for `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`)*

------
https://chatgpt.com/codex/tasks/task_e_689c45e7c2548326ab237cbd356c628f