### PR TITLE
test(e2e): purge vitest/jest from e2e; use Playwright expect only

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,5 +21,13 @@ export default [
       "no-implied-eval": "error",
       "no-alert": "error"
     }
+  },
+  {
+    files: ['e2e/**/*.{js,ts}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        paths: ['vitest', '@jest/globals', 'expect', '@vitest/expect']
+      }]
+    }
   }
 ];


### PR DESCRIPTION
## Summary
- add ESLint override to ban vitest/jest imports in e2e specs
- ensure vitest only scopes to unit tests and api test helpers

## Checks
- `npm run lint`
- `npm run test`
- `npx playwright install --with-deps` *(fails: repository not signed)*
- `npm run e2e` *(fails: browsers missing)*
- `npm run e2e:codex`

## Security/CSP
- no CSP changes; no external scripts added

## i18n
- no user-facing strings added

## Verification Log
- `npm run lint`
- `npm run test`
- `npx playwright install --with-deps` *(fails: repository not signed)*
- `npm run e2e` *(fails: browsers missing)*
- `npm run e2e:codex`

------
https://chatgpt.com/codex/tasks/task_e_689c4c723c448326bd422fddd13c4c9c