### PR TITLE
chore(lockfile): sync package-lock.json with package.json

### DIFF
--- a/scripts/check-lock.mjs
+++ b/scripts/check-lock.mjs
@@ -1,14 +1,10 @@
-/* eslint-env node */
 import fs from 'node:fs';
 const pkg = JSON.parse(fs.readFileSync('package.json','utf8'));
 const lock = JSON.parse(fs.readFileSync('package-lock.json','utf8'));
-if (!lock.packages) {
-  console.error('Lockfile missing packages map'); process.exit(1);
-}
-const missing = Object.entries({...pkg.dependencies, ...pkg.devDependencies})
-  .filter(([name]) => !Object.keys(lock.packages).some(k => k === `node_modules/${name}` || name === lock.name));
-if (missing.length) {
-  console.error('Lockfile out of sync for:', missing.map(([n])=>n).join(', '));
-  process.exit(1);
-}
+if (!lock.packages) { console.error('Lockfile missing packages map'); process.exit(1); }
+const wanted = { ...(pkg.dependencies||{}), ...(pkg.devDependencies||{}) };
+const missing = Object.keys(wanted).filter(
+  name => !Object.keys(lock.packages).some(k => k === `node_modules/${name}`)
+);
+if (missing.length) { console.error('Lockfile out of sync for:', missing.join(', ')); process.exit(1); }
 console.log('Lockfile matches package.json');


### PR DESCRIPTION
## Summary
- Regenerate lockfile and add check script to ensure package-lock.json matches dependencies

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browsers unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_689d0017bf308326849a8f3ab724c386