### PR TITLE
Add text parsing utility and tests

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,5 +1,6 @@
 import { createI18n } from '/utils/i18n.js';
 import { buildPrompt } from '/utils/copilot.js';
+import { parseText } from '/utils/parser.js';
 
 const state = {
   settings: null,
@@ -153,7 +154,7 @@ async function onDrop(e) {
   if (!file) return;
   if (file.type === 'text/plain') {
     const text = await file.text();
-    preview(parseToNormalizedRecord(text));
+    preview(parseText(text));
   } else if (file.type === 'application/pdf' || file.name.endsWith('.pdf')) {
     preview({ error: 'PDF parsing stub — add pdf.js (self-hosted) later.' });
   } else {
@@ -163,29 +164,11 @@ async function onDrop(e) {
 function onPaste(e) {
   const text = e.clipboardData?.getData('text');
   if (text && text.length > 5) {
-    preview(parseToNormalizedRecord(text));
+    preview(parseText(text));
   }
 }
 function preview(obj) {
   document.getElementById('preview').textContent = JSON.stringify(obj, null, 2);
-}
-function parseToNormalizedRecord(text) {
-  // naive extractor demo; refine in Codex task D
-  const lower = text.toLowerCase();
-  return {
-    carrier: (/verizon|at&t|cricket/.exec(lower) || ['unknown'])[0],
-    fees: findSection(lower, /(fee|charge|surcharge)/g),
-    dates: findSection(lower, /(effective|date|updated)/g),
-    prohibited: findSection(lower, /(prohibit|not allowed|forbidden)/g),
-    links: Array.from(text.matchAll(/https?:\/\/\S+/g)).map((m) => m[0]),
-    rawLength: text.length,
-    lang: localStorage.getItem('lang') || 'en',
-  };
-}
-function findSection(text, rx) {
-  const idx = text.search(rx);
-  if (idx < 0) return null;
-  return text.slice(idx, idx + 240);
 }
 
 // --- Copilot ---

--- a/public/utils/parser.js
+++ b/public/utils/parser.js
@@ -1,0 +1,36 @@
+// public/utils/parser.js
+// Normalizes pasted text into a record the UI can preview.
+// PDF handling will be added later (self-hosted pdf.js).
+export function parseText(input) {
+  const text = String(input || '');
+  const lower = text.toLowerCase();
+
+  const carrier = detectCarrier(lower);
+  const section = (rx) => sliceOriginal(text, lower, rx, 240);
+  const links = Array.from(text.matchAll(/https?:\/\/\S+/g)).map((m) => m[0]);
+
+  return {
+    carrier,
+    fees: section(/(fee|charge|surcharge)/g),
+    dates: section(/(effective|date|updated)/g),
+    prohibited: section(/(prohibit|not allowed|forbidden|restriction)/g),
+    links,
+    rawLength: text.length,
+  };
+}
+
+function detectCarrier(lower) {
+  const m = /(verizon|at&t|att|cricket|t-mobile|tmobile)/.exec(lower);
+  if (!m) return 'unknown';
+  const raw = m[1];
+  if (raw === 'att') return 'at&t';
+  if (raw === 'tmobile') return 't-mobile';
+  return raw;
+}
+
+function sliceOriginal(orig, lower, rx, span) {
+  const m = rx.exec(lower);
+  if (!m) return null;
+  const idx = m.index;
+  return orig.slice(idx, Math.min(idx + span, orig.length));
+}

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -1,0 +1,30 @@
+// tests/parser.test.js
+import { describe, it, expect } from 'vitest';
+import { parseText } from '../public/utils/parser.js';
+
+describe('parseText()', () => {
+  it('extracts carrier, sections, and links', () => {
+    const sample = `
+      VERIZON Wireless Terms of Service
+      Effective date: 2025-01-01
+      A re-stocking fee may apply. See https://example.com/policy
+      Certain actions are prohibited by policy.
+    `;
+    const out = parseText(sample);
+    expect(out.carrier).toBe('verizon');
+    expect(out.dates?.toLowerCase()).toContain('effective');
+    expect(out.fees?.toLowerCase()).toContain('fee');
+    expect(out.prohibited?.toLowerCase()).toContain('prohibit');
+    expect(out.links).toContain('https://example.com/policy');
+    expect(out.rawLength).toBeGreaterThan(20);
+  });
+
+  it('normalizes carrier names like att/tmobile', () => {
+    expect(parseText('ATT policy').carrier).toBe('at&t');
+    expect(parseText('TMobile notice').carrier).toBe('t-mobile');
+  });
+
+  it('returns unknown when no carrier is present', () => {
+    expect(parseText('hello world').carrier).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary
- factor out text parsing into dedicated utility for carrier, fee, date, restriction, and link extraction
- use parser utility in drop and paste handlers
- cover parser logic with unit tests

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1129/chrome-linux/chrome; ::note::E2E skipped (browsers unavailable in this environment). CI will run them.)*
- `npm run dev` + curl `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`

## Security/CSP
- No external scripts added; existing CSP remains in place.

## i18n
- No user-facing strings added or changed.

## Verification log
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(skipped due to missing browsers)*
- `npm run dev` + curl `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`


------
https://chatgpt.com/codex/tasks/task_e_68a2a76d44a083269bfbee3ceeadf40e