### PR TITLE
feat: add localized splash and title

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,4 +1,8 @@
 {
+  "AppTitle": "CST SmartDesk — Escalation Toolkit",
+  "Start": "Start",
+  "WelcomeTitle": "Welcome",
+  "WelcomeBlurb": "Fast, reliable, bilingual tools to serve, solve, and sell.",
   "Drop PDF/TXT here or paste text (Ctrl+V).": "Drop PDF/TXT here or paste text (Ctrl+V).",
   "System Status": "System Status",
   "First-Run Setup": "First-Run Setup",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -1,4 +1,8 @@
 {
+  "AppTitle": "CST SmartDesk — Herramientas de Escalación",
+  "Start": "Comenzar",
+  "WelcomeTitle": "Bienvenido",
+  "WelcomeBlurb": "Herramientas rápidas y bilingües para servir, resolver y vender.",
   "Drop PDF/TXT here or paste text (Ctrl+V).": "Suelta PDF/TXT aquí o pega texto (Ctrl+V).",
   "System Status": "Estado del sistema",
   "First-Run Setup": "Configuración inicial",

--- a/index.html
+++ b/index.html
@@ -1,71 +1,84 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://api.openai.com; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>CST SmartDesk — Escalation Toolkit</title>
-  <link rel="stylesheet" href="/styles/tokens.css"/>
-</head>
-<body>
-  <header class="topbar">
-    <h1 id="appTitle">CST SmartDesk</h1>
-    <div class="top-actions">
-      <button id="langToggle" aria-label="Language">EN/ES</button>
-      <button id="openTests">Tests</button>
-      <button id="openSettings" aria-controls="setupWizard">Settings</button>
-    </div>
-  </header>
-
-  <aside class="sidebar">
-    <div class="carriers">
-      <img src="/assets/verizon.svg" alt="Verizon" />
-      <img src="/assets/att.svg" alt="AT&T" />
-      <img src="/assets/cricket.svg" alt="Cricket" />
-    </div>
-  </aside>
-
-  <main class="content">
-    <section class="dropzone" id="dropzone" aria-label="Drag & drop files">
-      <p id="dzText">Drop PDF/TXT here or paste text (Ctrl+V).</p>
-      <pre id="preview" class="preview"></pre>
-    </section>
-
-    <section id="systemStatus" class="status">
-      <h2>System Status</h2>
-      <ul id="statusList"></ul>
-    </section>
-  </main>
-
-  <!-- Setup Wizard -->
-  <dialog id="setupWizard">
-    <form method="dialog" id="wizardForm">
-      <h3>First-Run Setup</h3>
-      <label>Expert Name <input id="wName" required /></label>
-      <label>Employee ID <input id="wEmpId" required /></label>
-      <label>CST Extension <input id="wExt" required /></label>
-      <label>Theme
-        <select id="wTheme">
-          <option value="light">Light</option>
-          <option value="dark">Dark</option>
-        </select>
-      </label>
-      <label><input type="checkbox" id="dontShow"/> Don’t show again</label>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://api.openai.com; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title data-i18n="AppTitle">CST SmartDesk — Escalation Toolkit</title>
+    <link rel="stylesheet" href="/styles/tokens.css" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <h1 id="appTitle">CST SmartDesk</h1>
+      <div class="top-actions">
+        <button id="langToggle" aria-label="Language">EN/ES</button>
+        <button id="openTests">Tests</button>
+        <button id="openSettings" aria-controls="setupWizard">Settings</button>
+      </div>
+    </header>
+    <!-- Splash (first visit) -->
+    <dialog id="splash">
+      <h3 data-i18n="WelcomeTitle">Welcome</h3>
+      <p data-i18n="WelcomeBlurb">Fast, reliable, bilingual tools to serve, solve, and sell.</p>
       <menu>
-        <button value="cancel">Cancel</button>
-        <button id="wizardSave" value="save">Save</button>
+        <button id="splashStart" data-i18n="Start">Start</button>
       </menu>
-    </form>
-  </dialog>
+    </dialog>
 
-  <!-- Tests Modal -->
-  <dialog id="testsModal">
-    <h3>Tests</h3>
-    <button id="testsFetchBtn">Fetch Verizon T&C</button>
-    <pre id="testsOutput"></pre>
-    <menu><button id="testsClose">Close</button></menu>
-  </dialog>
+    <aside class="sidebar">
+      <div class="carriers">
+        <img src="/assets/verizon.svg" alt="Verizon" />
+        <img src="/assets/att.svg" alt="AT&T" />
+        <img src="/assets/cricket.svg" alt="Cricket" />
+      </div>
+    </aside>
 
-  <script type="module" src="/app.js" defer></script>
-</body>
+    <main class="content">
+      <section class="dropzone" id="dropzone" aria-label="Drag & drop files">
+        <p id="dzText">Drop PDF/TXT here or paste text (Ctrl+V).</p>
+        <pre id="preview" class="preview"></pre>
+      </section>
+
+      <section id="systemStatus" class="status">
+        <h2>System Status</h2>
+        <ul id="statusList"></ul>
+      </section>
+    </main>
+
+    <!-- Setup Wizard -->
+    <dialog id="setupWizard">
+      <form method="dialog" id="wizardForm">
+        <h3>First-Run Setup</h3>
+        <label>Expert Name <input id="wName" required /></label>
+        <label>Employee ID <input id="wEmpId" required /></label>
+        <label>CST Extension <input id="wExt" required /></label>
+        <label
+          >Theme
+          <select id="wTheme">
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+        <label><input type="checkbox" id="dontShow" /> Don’t show again</label>
+        <menu>
+          <button value="cancel">Cancel</button>
+          <button id="wizardSave" value="save">Save</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <!-- Tests Modal -->
+    <dialog id="testsModal">
+      <h3>Tests</h3>
+      <button id="testsFetchBtn">Fetch Verizon T&C</button>
+      <pre id="testsOutput"></pre>
+      <menu><button id="testsClose">Close</button></menu>
+    </dialog>
+
+    <script type="module" src="/app.js" defer></script>
+  </body>
 </html>

--- a/public/app.js
+++ b/public/app.js
@@ -9,6 +9,7 @@ const state = {
   lastFetchRun: null,
   copilotSamples: [],
   copilotReachable: null,
+  splashShown: false,
   lang: 'en',
 };
 
@@ -38,6 +39,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const lang = localStorage.getItem('lang') || 'en';
   state.i18n = await createI18n(lang);
   state.lang = lang;
+  // localize static title immediately
+  localizeStatic();
   document.getElementById('langToggle').addEventListener('click', toggleLang);
 
   // setup wizard
@@ -47,7 +50,19 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('wizardSave').addEventListener('click', onSaveWizard);
   state.settings = loadSettings();
 
-  if (!onboarded) wiz.showModal();
+  // splash first
+  const splash = document.getElementById('splash');
+  if (!localStorage.getItem('splashDone') && splash?.showModal) {
+    splash.showModal();
+    document.getElementById('splashStart').addEventListener('click', () => {
+      splash.close();
+      localStorage.setItem('splashDone', '1');
+      // immediately open wizard on very first run
+      if (!onboarded) wiz.showModal();
+    });
+  } else if (!onboarded) {
+    wiz.showModal();
+  }
 
   // tests modal
   const testsModal = document.getElementById('testsModal');
@@ -94,8 +109,17 @@ async function toggleLang() {
   localStorage.setItem('lang', next);
   state.i18n = await createI18n(next);
   state.lang = next;
+  localizeStatic();
   renderCopilotUI();
   renderStatus();
+}
+
+function localizeStatic() {
+  document
+    .querySelectorAll('[data-i18n]')
+    .forEach((el) => (el.textContent = state.i18n.t(el.dataset.i18n)));
+  const title = document.querySelector('title[data-i18n]');
+  if (title) title.textContent = state.i18n.t(title.dataset.i18n);
 }
 
 // --- Setup Wizard ---

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,17 @@
+/* Minimal global/app polish */
+dialog#splash {
+  max-width: 560px;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+}
+dialog#splash::backdrop {
+  background: rgba(0, 0, 0, 0.35);
+}
+menu {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+button {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add i18n-ready title and first-run splash screen
- provide minimal global styling for splash dialog
- localize static elements on language toggle

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: missing Playwright browsers)*
- `curl -I http://localhost:4173/`
- `curl -I http://localhost:4173/app.js`
- `curl -I http://localhost:4173/assets/logo.svg`
- `curl -i http://localhost:4173/api/fetch`


------
https://chatgpt.com/codex/tasks/task_e_68a2adc4219883269b914e4fcd936168