### PR TITLE
feat: add dark theme support

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -41,6 +41,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   state.lang = lang;
   // localize static title immediately
   localizeStatic();
+  applyTheme(loadSettings()?.theme || 'light');
   document.getElementById('langToggle').addEventListener('click', toggleLang);
 
   // setup wizard
@@ -145,6 +146,7 @@ function val(sel) {
 function saveSettings(s) {
   localStorage.setItem('cst.settings', JSON.stringify(s));
   state.settings = s;
+  if (s.theme) applyTheme(s.theme);
 }
 function loadSettings() {
   try {
@@ -152,6 +154,10 @@ function loadSettings() {
   } catch {
     return {};
   }
+}
+
+function applyTheme(name) {
+  document.documentElement.classList.toggle('theme-dark', name === 'dark');
 }
 
 // --- Tests Modal action ---

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,3 +1,35 @@
+/* Theme tokens (light/dark) */
+:root {
+  --bg: #ffffff;
+  --fg: #111111;
+  --card: #f5f7fa;
+  --accent: #2b6cb0;
+}
+:root.theme-dark {
+  --bg: #0b0f14;
+  --fg: #e7ecf3;
+  --card: #141a22;
+  --accent: #63b3ed;
+}
+html,
+body {
+  background: var(--bg);
+  color: var(--fg);
+}
+.topbar,
+.status,
+dialog,
+.preview {
+  background: var(--card);
+}
+button {
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+}
+
 /* Minimal global/app polish */
 dialog#splash {
   max-width: 560px;


### PR DESCRIPTION
## Summary
- add light/dark theme tokens and styling
- switch theme via saved settings

## Checks
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: missing browsers)*
- `npm run dev` (4-point URL check)

## Security/CSP
- no external scripts added; CSP headers remain intact

## i18n
- no user-facing strings added

## Verification log
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: missing browsers)*
- `npm run dev` (4-point URL check)

------
https://chatgpt.com/codex/tasks/task_e_68a2b766dae483269e1aeb17c87f032c