### PR TITLE
feat: add highlights section

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -8,3 +8,9 @@ test('loads app and status panel', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'CST SmartDesk' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'System Status' })).toBeVisible();
 });
+
+test('highlights section toggles language', async ({ page }) => {
+  await expect(page.getByRole('heading', { name: 'Highlights' })).toBeVisible();
+  await page.getByRole('button', { name: 'Language' }).click();
+  await expect(page.getByRole('heading', { name: 'Aspectos destacados' })).toBeVisible();
+});

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -17,5 +17,7 @@
   "Copy ES": "Copy ES",
   "Loading...": "Loading...",
   "Set OPENAI_API_KEY in Vercel to enable Copilot.": "Set OPENAI_API_KEY in Vercel to enable Copilot.",
-  "Copilot reachable": "Copilot reachable"
+  "Copilot reachable": "Copilot reachable",
+  "Highlights": "Highlights",
+  "HighlightsIntro": "Top tips and updates for CST experts"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -17,5 +17,7 @@
   "Copy ES": "Copiar ES",
   "Loading...": "Cargando...",
   "Set OPENAI_API_KEY in Vercel to enable Copilot.": "Configure OPENAI_API_KEY en Vercel para habilitar Copilot.",
-  "Copilot reachable": "Copilot alcanzable"
+  "Copilot reachable": "Copilot alcanzable",
+  "Highlights": "Aspectos destacados",
+  "HighlightsIntro": "Consejos y actualizaciones principales para expertos de CST"
 }

--- a/index.html
+++ b/index.html
@@ -29,6 +29,13 @@
       </menu>
     </dialog>
 
+    <!-- New visible section -->
+    <section id="highlights" aria-labelledby="highlightsTitle">
+      <h2 id="highlightsTitle" data-i18n="Highlights">Highlights</h2>
+      <p data-i18n="HighlightsIntro">Top tips and updates for CST experts</p>
+      <div class="hero-placeholder" role="img" aria-label="Highlights banner"></div>
+    </section>
+
     <aside class="sidebar">
       <div class="carriers">
         <img src="/assets/verizon.svg" alt="Verizon" />

--- a/public/styles.css
+++ b/public/styles.css
@@ -47,3 +47,23 @@ menu {
 button {
   cursor: pointer;
 }
+
+/* Highlights section with gradient placeholder */
+#highlights {
+  margin: 1.5rem 0 2rem;
+  padding: 0 1rem;
+}
+#highlights h2 {
+  margin: 0.5rem 0;
+}
+#highlights p {
+  margin: 0.25rem 0 1rem;
+  color: var(--fg);
+}
+.hero-placeholder {
+  width: 100%;
+  height: 220px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #dbeafe, #e9d5ff);
+  border: 1px solid #e6e6e6;
+}


### PR DESCRIPTION
## Summary
- add homepage Highlights section and styling
- translate new copy to Spanish
- test Highlights language toggle

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browsers missing; see log)*
- `npm run dev` (4-point URL smoke)


------
https://chatgpt.com/codex/tasks/task_e_68a2bc8f662c83268c501c9c98487053