### PR TITLE
feat: add setup wizard localization and splash overlay

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -19,5 +19,16 @@
   "Set OPENAI_API_KEY in Vercel to enable Copilot.": "Set OPENAI_API_KEY in Vercel to enable Copilot.",
   "Copilot reachable": "Copilot reachable",
   "Highlights": "Highlights",
-  "HighlightsIntro": "Top tips and updates for CST experts"
+  "HighlightsIntro": "Top tips and updates for CST experts",
+  "SetupTitle": "First-Run Setup",
+  "SetupName": "Expert Name",
+  "SetupEmpId": "Employee ID",
+  "SetupExt": "CST Extension",
+  "SetupTheme": "Theme",
+  "DontShowAgain": "Don’t show again",
+  "Cancel": "Cancel",
+  "Save": "Save",
+  "SetupNamePlaceholder": "Enter your name",
+  "SetupEmpIdPlaceholder": "Enter your employee ID",
+  "SetupExtPlaceholder": "Enter your CST extension"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -19,5 +19,16 @@
   "Set OPENAI_API_KEY in Vercel to enable Copilot.": "Configure OPENAI_API_KEY en Vercel para habilitar Copilot.",
   "Copilot reachable": "Copilot alcanzable",
   "Highlights": "Aspectos destacados",
-  "HighlightsIntro": "Consejos y actualizaciones principales para expertos de CST"
+  "HighlightsIntro": "Consejos y actualizaciones principales para expertos de CST",
+  "SetupTitle": "Configuración inicial",
+  "SetupName": "Nombre del experto",
+  "SetupEmpId": "ID de empleado",
+  "SetupExt": "Extensión CST",
+  "SetupTheme": "Tema",
+  "DontShowAgain": "No mostrar de nuevo",
+  "Cancel": "Cancelar",
+  "Save": "Guardar",
+  "SetupNamePlaceholder": "Ingresa tu nombre",
+  "SetupEmpIdPlaceholder": "Ingresa tu ID de empleado",
+  "SetupExtPlaceholder": "Ingresa tu extensión CST"
 }

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
+    <div id="splash" aria-hidden="true">CST SmartDesk</div>
     <header class="topbar">
       <h1 id="appTitle">CST SmartDesk</h1>
       <div class="top-actions">
@@ -20,15 +21,6 @@
         <button id="openSettings" aria-controls="setupWizard">Settings</button>
       </div>
     </header>
-    <!-- Splash (first visit) -->
-    <dialog id="splash">
-      <h3 data-i18n="WelcomeTitle">Welcome</h3>
-      <p data-i18n="WelcomeBlurb">Fast, reliable, bilingual tools to serve, solve, and sell.</p>
-      <menu>
-        <button id="splashStart" data-i18n="Start">Start</button>
-      </menu>
-    </dialog>
-
     <!-- New visible section -->
     <section id="highlights" aria-labelledby="highlightsTitle">
       <h2 id="highlightsTitle" data-i18n="Highlights">Highlights</h2>
@@ -59,21 +51,48 @@
     <!-- Setup Wizard -->
     <dialog id="setupWizard">
       <form method="dialog" id="wizardForm">
-        <h3>First-Run Setup</h3>
-        <label>Expert Name <input id="wName" required /></label>
-        <label>Employee ID <input id="wEmpId" required /></label>
-        <label>CST Extension <input id="wExt" required /></label>
+        <h3 data-i18n="SetupTitle">First-Run Setup</h3>
         <label
-          >Theme
+          ><span data-i18n="SetupName">Expert Name</span>
+          <input
+            id="wName"
+            required
+            data-i18n-placeholder="SetupNamePlaceholder"
+            placeholder="Enter your name"
+          />
+        </label>
+        <label
+          ><span data-i18n="SetupEmpId">Employee ID</span>
+          <input
+            id="wEmpId"
+            required
+            data-i18n-placeholder="SetupEmpIdPlaceholder"
+            placeholder="Enter your employee ID"
+          />
+        </label>
+        <label
+          ><span data-i18n="SetupExt">CST Extension</span>
+          <input
+            id="wExt"
+            required
+            data-i18n-placeholder="SetupExtPlaceholder"
+            placeholder="Enter your CST extension"
+          />
+        </label>
+        <label
+          ><span data-i18n="SetupTheme">Theme</span>
           <select id="wTheme">
             <option value="light">Light</option>
             <option value="dark">Dark</option>
           </select>
         </label>
-        <label><input type="checkbox" id="dontShow" /> Don’t show again</label>
+        <label
+          ><input type="checkbox" id="dontShow" />
+          <span data-i18n="DontShowAgain">Don’t show again</span></label
+        >
         <menu>
-          <button value="cancel">Cancel</button>
-          <button id="wizardSave" value="save">Save</button>
+          <button value="cancel" data-i18n="Cancel">Cancel</button>
+          <button id="wizardSave" value="save" data-i18n="Save">Save</button>
         </menu>
       </form>
     </dialog>

--- a/public/app.js
+++ b/public/app.js
@@ -41,6 +41,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   state.lang = lang;
   // localize static title immediately
   localizeStatic();
+  showSplash();
   applyTheme(loadSettings()?.theme || 'light');
   document.getElementById('langToggle').addEventListener('click', toggleLang);
 
@@ -51,17 +52,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('wizardSave').addEventListener('click', onSaveWizard);
   state.settings = loadSettings();
 
-  // splash first
-  const splash = document.getElementById('splash');
-  if (!localStorage.getItem('splashDone') && splash?.showModal) {
-    splash.showModal();
-    document.getElementById('splashStart').addEventListener('click', () => {
-      splash.close();
-      localStorage.setItem('splashDone', '1');
-      // immediately open wizard on very first run
-      if (!onboarded) wiz.showModal();
-    });
-  } else if (!onboarded) {
+  if (!onboarded) {
     wiz.showModal();
   }
 
@@ -121,6 +112,22 @@ function localizeStatic() {
     .forEach((el) => (el.textContent = state.i18n.t(el.dataset.i18n)));
   const title = document.querySelector('title[data-i18n]');
   if (title) title.textContent = state.i18n.t(title.dataset.i18n);
+  document
+    .querySelectorAll('[data-i18n-placeholder]')
+    .forEach((el) => (el.placeholder = state.i18n.t(el.dataset.i18nPlaceholder)));
+}
+
+function showSplash() {
+  try {
+    const el = document.getElementById('splash');
+    if (!el) return;
+    requestAnimationFrame(() => {
+      el.classList.add('show');
+      setTimeout(() => el.classList.remove('show'), 900);
+    });
+  } catch {
+    /* noop */
+  }
 }
 
 // --- Setup Wizard ---

--- a/public/styles.css
+++ b/public/styles.css
@@ -31,14 +31,6 @@ button {
 }
 
 /* Minimal global/app polish */
-dialog#splash {
-  max-width: 560px;
-  border-radius: 12px;
-  padding: 1.25rem 1.5rem;
-}
-dialog#splash::backdrop {
-  background: rgba(0, 0, 0, 0.35);
-}
 menu {
   display: flex;
   gap: 0.5rem;
@@ -66,4 +58,20 @@ button {
   border-radius: 12px;
   background: linear-gradient(135deg, #dbeafe, #e9d5ff);
   border: 1px solid #e6e6e6;
+}
+/* Splash overlay – purely visual, non-blocking */
+#splash {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: clamp(20px, 4vw, 40px);
+  background: radial-gradient(1200px 600px at 50% -10%, #f5f7ff, #ffffff 60%);
+  color: #1b1f24;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+}
+#splash.show {
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary
- localize setup wizard labels and placeholders with new i18n keys
- add brief, non-blocking splash overlay on startup
- style splash overlay for smooth fade in/out

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browsers unavailable)*

## Security/CSP
- no external scripts; existing CSP remains intact

## i18n
- added: `SetupTitle`, `SetupName`, `SetupEmpId`, `SetupExt`, `SetupTheme`, `DontShowAgain`, `Cancel`, `Save`, `SetupNamePlaceholder`, `SetupEmpIdPlaceholder`, `SetupExtPlaceholder`

## Verification Log
- `npx prettier i18n/en.json i18n/es.json index.html public/app.js public/styles.css --write`
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browsers unavailable)*
- `curl -I http://localhost:4173/`
- `curl -I http://localhost:4173/app.js`
- `curl -I http://localhost:4173/assets/logo.svg`
- `curl http://localhost:4173/api/fetch`


------
https://chatgpt.com/codex/tasks/task_e_68a2cd759a2c83269e2bac86d3c01f88