### PR TITLE
feat: add local fallback copilot

### DIFF
--- a/api/copilot.js
+++ b/api/copilot.js
@@ -1,7 +1,6 @@
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
-    res.status(405).json({ error: 'Method Not Allowed' });
-    return;
+    return res.status(405).json({ ok: false, error: 'Method Not Allowed' });
   }
   try {
     const { prompt } = await readJson(req);


### PR DESCRIPTION
## Summary
- handle POST-only for copilot API with structured 405 errors
- add rules-based local Serve/Solve/Sell response when `OPENAI_API_KEY` is absent
- return bilingual English/Spanish text with optional follow-up note

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browser executable missing; CI will run)*
- `npm run dev` smoke for `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`

## Security/CSP
- no external scripts or CSP violations introduced

## i18n
- inline EN/ES strings in local fallback; no JSON keys added

## Verification log
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(browserType.launch executable missing)*
- `npm run dev` & `curl` checks for `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`


------
https://chatgpt.com/codex/tasks/task_e_68a2dec0bc708326bf796751f715794e