### PR TITLE
test: cover copilot follow-up

### DIFF
--- a/api/__tests__/copilot.local.test.js
+++ b/api/__tests__/copilot.local.test.js
@@ -36,4 +36,19 @@ describe('local copilot (no key)', () => {
     expect(res.jsonPayload).toHaveProperty('en');
     expect(res.jsonPayload).toHaveProperty('es');
   });
+
+  it('emphasizes follow-up when requested', async () => {
+    const { req, res } = mockReqRes({ prompt: 'please confirm and follow up' });
+    await handler(req, res);
+    expect(res.jsonPayload.en).toMatch(/follow up after your confirmation/i);
+    expect(res.jsonPayload.es).toMatch(/Haré seguimiento/i);
+  });
+
+  it('omits SSS heading and follow-up if not prompted', async () => {
+    const { req, res } = mockReqRes({ prompt: 'hello world' });
+    await handler(req, res);
+    expect(res.jsonPayload.en).toMatch(/concise response:/);
+    expect(res.jsonPayload.en).not.toMatch(/Serve \/ Solve \/ Sell/);
+    expect(res.jsonPayload.en).not.toMatch(/follow up after your confirmation/i);
+  });
 });


### PR DESCRIPTION
## Summary
- add tests ensuring copilot follow-up text and SSS heading behavior

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1129/chrome-linux/chrome)*

## Security
- no external scripts added; CSP verified via dev server

## i18n
- no user-facing strings changed

## Verification Log
- `npm run lint`
- `npm run test`
- `npm run e2e:codex`
- `npm run serve`
- `curl -I http://localhost:4173/`
- `curl -I http://localhost:4173/app.js`
- `curl -I http://localhost:4173/assets/logo.svg`
- `curl http://localhost:4173/api/fetch`

------
https://chatgpt.com/codex/tasks/task_e_68a2e39b8be0832690ada067e94b2ad6