### PR TITLE
Preserve CSS file names in Vite build output

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,15 @@ export default defineConfig({
       input: {
         main: './index.html',
       },
+      output: {
+        assetFileNames: (assetInfo) => {
+          // This ensures CSS files keep their names and are placed correctly
+          if (assetInfo.name === 'styles.css' || assetInfo.name === 'tokens.css') {
+            return 'styles/[name]-[hash][extname]';
+          }
+          return 'assets/[name]-[hash][extname]';
+        },
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- ensure CSS files retain names and route to styles folder during build

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browsers missing, CI will run)*
- `npm run dev` + curl `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`

## Security/CSP
- no external scripts added; existing CSP headers retained

## i18n
- no user-facing strings added

## Verification Log
- `npm run lint`
- `npm run test`
- `npm run e2e:codex`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a42c0d80908326a0037edd27f9509a