### PR TITLE
Fix splash banner id and image paths

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -119,7 +119,7 @@ function localizeStatic() {
 
 function showSplash() {
   try {
-    const el = document.getElementById('splash');
+    const el = document.getElementById('splashBanner');
     if (!el) return;
     requestAnimationFrame(() => {
       el.classList.add('show');

--- a/src/index.html
+++ b/src/index.html
@@ -47,9 +47,9 @@
 
     <aside class="sidebar">
       <div class="carriers">
-        <img src="/assets/verizon.svg" alt="Verizon" />
-        <img src="/assets/att.svg" alt="AT&T" />
-        <img src="/assets/cricket.svg" alt="Cricket" />
+        <img src="../assets/verizon.svg" alt="Verizon" />
+        <img src="../assets/att.svg" alt="AT&T" />
+        <img src="../assets/cricket.svg" alt="Cricket" />
       </div>
     </aside>
 


### PR DESCRIPTION
## Summary
- fix splash banner markup and carrier image paths
- target `splashBanner` id in splash helper

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browserType.launch: Executable doesn't exist)*
- `curl -I --max-time 5 http://localhost:4174/`
- `curl -I --max-time 5 http://localhost:4174/app.js`
- `curl -I --max-time 5 http://localhost:4174/assets/logo.svg`
- `curl -I --max-time 5 http://localhost:4174/api/fetch`


------
https://chatgpt.com/codex/tasks/task_e_68a4d773c60883268604b71dbca34a8b