### PR TITLE
fix splash banner visibility

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -41,7 +41,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   state.lang = lang;
   // localize static title immediately
   localizeStatic();
-  showSplash();
+
+  // SHOW SPLASH (new)
+  initSplash();
+
+  // theme + listeners...
   applyTheme(loadSettings()?.theme || 'light');
   document.getElementById('langToggle').addEventListener('click', toggleLang);
 
@@ -117,17 +121,36 @@ function localizeStatic() {
     .forEach((el) => (el.placeholder = state.i18n.t(el.dataset.i18nPlaceholder)));
 }
 
-function showSplash() {
-  try {
-    const el = document.getElementById('splash');
-    if (!el) return;
-    requestAnimationFrame(() => {
-      el.classList.add('show');
-      setTimeout(() => el.classList.remove('show'), 900);
-    });
-  } catch {
-    /* noop */
-  }
+// --- replace your existing showSplash() with this ---
+function initSplash() {
+  const el = document.getElementById('splash');
+  if (!el) return;
+
+  // respect prior dismiss/onboarding
+  const dismissed = localStorage.getItem('cst.splash.dismissed') === '1';
+  const onboarded = localStorage.getItem('onboarded') === '1';
+  if (dismissed || onboarded) return;
+
+  // actually show it
+  el.hidden = false; // ⬅️ key fix: unhide
+  requestAnimationFrame(() => {
+    el.classList.add('show'); // optional animation class
+  });
+
+  // buttons
+  const start = document.getElementById('splashStart');
+  const dismiss = document.getElementById('splashDismiss');
+
+  start?.addEventListener('click', () => {
+    el.hidden = true;
+    // guide user into the setup wizard on first use
+    document.getElementById('setupWizard')?.showModal();
+  });
+
+  dismiss?.addEventListener('click', () => {
+    el.hidden = true;
+    localStorage.setItem('cst.splash.dismissed', '1');
+  });
 }
 
 // --- Setup Wizard ---

--- a/src/styles.css
+++ b/src/styles.css
@@ -59,19 +59,29 @@ button {
   background: linear-gradient(135deg, #dbeafe, #e9d5ff);
   border: 1px solid #e6e6e6;
 }
-/* Splash overlay – purely visual, non-blocking */
-#splash {
-  position: fixed;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  font-size: clamp(20px, 4vw, 40px);
-  background: radial-gradient(1200px 600px at 50% -10%, #f5f7ff, #ffffff 60%);
-  color: #1b1f24;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.4s ease;
+/* Splash banner basics */
+.banner {
+  margin: 1rem 0;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  background: #f6f8fb;
+  border: 1px solid #e5e9f2;
 }
-#splash.show {
-  opacity: 1;
+.banner .banner-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+.banner.show {
+  animation: fadeIn 0.28s ease-out;
+}
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }


### PR DESCRIPTION
## Summary
- unhide splash banner only for first-time users and wire start/dismiss buttons
- style splash banner and animate on reveal

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browsers unavailable)*
- `curl -I http://localhost:4173/`
- `curl -I http://localhost:4173/app.js`
- `curl -I http://localhost:4173/assets/logo.svg`
- `curl http://localhost:4173/api/fetch`

## Security/CSP
- No external scripts added; existing CSP headers respected.

## i18n
- No new strings

## Verification Log
- `npm run lint`
- `npm run test`
- `npm run e2e:codex`
- `node scripts/dev-server.mjs` & `curl -I http://localhost:4173/`
- `curl -I http://localhost:4173/app.js`
- `curl -I http://localhost:4173/assets/logo.svg`
- `curl http://localhost:4173/api/fetch`


------
https://chatgpt.com/codex/tasks/task_e_68a609014f4c8326b73adc3f4660934b