### PR TITLE
fix(csp): remove inline styles and allow vercel.live

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -237,13 +237,13 @@ function initCopilot() {
     <label><span id="copilotSampleLabel"></span><select id="copilotSample"></select></label>
     <label><span id="copilotInputLabel"></span><textarea id="copilotInput"></textarea></label>
     <button id="copilotRun"></button>
-    <div id="copilotOutput" style="display:flex;gap:1rem">
-      <div style="flex:1">
+    <div id="copilotOutput" class="copilot-output">
+      <div class="copilot-col">
         <h3 id="copilotEnLabel"></h3>
         <pre id="copilotEn" class="preview"></pre>
         <button id="copilotCopyEn"></button>
       </div>
-      <div style="flex:1">
+      <div class="copilot-col">
         <h3 id="copilotEsLabel"></h3>
         <pre id="copilotEs" class="preview"></pre>
         <button id="copilotCopyEs"></button>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://vercel.live; style-src 'self'; img-src 'self' data:; connect-src 'self' https://api.openai.com; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+      content="default-src 'self'; script-src 'self' https://vercel.live; style-src 'self'; img-src 'self' data:; connect-src 'self' https://api.openai.com https://vercel.live; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>CST SmartDesk — Escalation Toolkit</title>

--- a/src/styles.css
+++ b/src/styles.css
@@ -87,3 +87,14 @@ body {
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
   margin: 1rem 0 2rem;
 }
+
+/* Copilot layout (replaces inline styles blocked by CSP) */
+.copilot-output {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.copilot-col {
+  flex: 1 1 320px;
+  min-width: 280px;
+}


### PR DESCRIPTION
## Summary
- replace Copilot inline styles with CSS classes
- allow vercel.live in script and connect CSP
- add Copilot layout classes in styles.css

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: missing Playwright browsers)*
- `npm run build`
- `curl -I http://localhost:4174/` *(dev server check)*
- `curl -I http://localhost:4174/app.js`
- `curl -I http://localhost:4174/assets/logo.svg`
- `curl -I http://localhost:4174/api/fetch`

## Security/CSP
- No external scripts added
- CSP updated to permit vercel.live script and connect

## i18n
- No new strings

## Verification Log
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(missing browsers)*
- `npm run build`
- `npm run dev` + 4-point URL smoke


------
https://chatgpt.com/codex/tasks/task_e_68a814bec3d883268a5523c057110e29