### PR TITLE
feat(splash): add loading bar with localized messages

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -45,15 +45,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   // SHOW SPLASH (new)
   showSplash();
 
-  document.getElementById('splashStart')?.addEventListener('click', () => {
-    const s = document.getElementById('splash');
-    if (s) s.hidden = true;
-  });
-  document.getElementById('splashDismiss')?.addEventListener('click', () => {
-    const s = document.getElementById('splash');
-    if (s) s.hidden = true;
-  });
-
   // theme + listeners...
   applyTheme(loadSettings()?.theme || 'light');
   document.getElementById('langToggle').addEventListener('click', toggleLang);
@@ -116,6 +107,10 @@ async function toggleLang() {
   localStorage.setItem('lang', next);
   state.i18n = await createI18n(next);
   state.lang = next;
+  const msg = document.getElementById('splashMsg');
+  if (msg && msg.dataset.i18n) {
+    msg.textContent = state.i18n.t(msg.dataset.i18n);
+  }
   localizeStatic();
   renderCopilotUI();
   renderStatus();
@@ -136,12 +131,13 @@ function showSplash() {
   try {
     const el = document.getElementById('splash');
     if (!el) return;
-    // Unhide first, then animate
-    el.hidden = false;
-    requestAnimationFrame(() => {
-      el.classList.add('show');
-      setTimeout(() => el.classList.remove('show'), 900);
-    });
+    el.hidden = false; // unhide for SSR/meta CSP
+    el.classList.add('show'); // CSS-controlled visibility
+    const msg = document.getElementById('splashMsg');
+    if (msg) {
+      msg.dataset.i18n = 'LoadingSplash';
+      msg.textContent = state.i18n.t('LoadingSplash');
+    }
   } catch {
     /* noop */
   }
@@ -371,6 +367,22 @@ async function run4PointUrlTest() {
   );
   state.urlTest = Object.fromEntries(results);
   renderStatus();
+
+  // mark splash bar done and close shortly after
+  const prog = document.querySelector('#splash .progress');
+  const msg = document.getElementById('splashMsg');
+  if (prog) prog.classList.add('done');
+  if (msg) {
+    msg.dataset.i18n = 'Ready';
+    msg.textContent = state.i18n.t('Ready');
+  }
+  setTimeout(() => {
+    const el = document.getElementById('splash');
+    if (el) {
+      el.classList.remove('show');
+      el.hidden = true;
+    }
+  }, 700);
 }
 function renderStatus() {
   const items = [];
@@ -447,3 +459,16 @@ function escapeHtml(s) {
     (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' })[c],
   );
 }
+
+const splashDismiss = document.getElementById('splashDismiss');
+const splashStart = document.getElementById('splashStart');
+[splashDismiss, splashStart].forEach((btn) => {
+  if (btn)
+    btn.addEventListener('click', () => {
+      const el = document.getElementById('splash');
+      if (el) {
+        el.classList.remove('show');
+        el.hidden = true;
+      }
+    });
+});

--- a/src/index.html
+++ b/src/index.html
@@ -37,6 +37,12 @@
             Faster serve/solve/sell with bilingual responses, carrier checks, and a secure
             workspace.
           </p>
+          <p id="splashMsg" class="banner-msg" data-i18n="LoadingSplash">
+            Loading CST SmartDesk — stand by…
+          </p>
+          <div class="progress" aria-hidden="true">
+            <div class="bar" role="presentation"></div>
+          </div>
           <div class="banner-actions">
             <button id="splashStart" class="btn-primary" data-i18n="Get Started">
               Get Started

--- a/src/public/i18n/en.json
+++ b/src/public/i18n/en.json
@@ -35,5 +35,7 @@
   "Welcome": "Welcome to CST SmartDesk",
   "WelcomeIntro": "Faster serve/solve/sell with bilingual responses, carrier checks, and a secure workspace.",
   "Get Started": "Get Started",
-  "Dismiss": "Dismiss"
+  "Dismiss": "Dismiss",
+  "LoadingSplash": "Loading CST SmartDesk — stand by…",
+  "Ready": "Ready"
 }

--- a/src/public/i18n/es.json
+++ b/src/public/i18n/es.json
@@ -35,5 +35,7 @@
   "Welcome": "Bienvenido a CST SmartDesk",
   "WelcomeIntro": "Sirve/resuelve/vende más rápido con respuestas bilingües, verificaciones de operadores y un espacio de trabajo seguro.",
   "Get Started": "Comenzar",
-  "Dismiss": "Descartar"
+  "Dismiss": "Descartar",
+  "LoadingSplash": "Cargando CST SmartDesk — espere…",
+  "Ready": "Listo"
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -98,3 +98,61 @@ body {
   flex: 1 1 320px;
   min-width: 280px;
 }
+
+/* Splash banner + progress */
+.banner {
+  display: none;
+  padding: 1rem 0;
+  background: #f8fafc;
+  border-bottom: 1px solid #e5e7eb;
+}
+.banner.show {
+  display: block;
+}
+.banner-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+.banner-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.banner-msg {
+  color: #334155;
+  font-size: 0.95rem;
+}
+.progress {
+  position: relative;
+  height: 6px;
+  background: #e5e7eb;
+  border-radius: 999px;
+  overflow: hidden;
+}
+.progress .bar {
+  height: 100%;
+  background: #16a34a;
+}
+@keyframes loadPulse {
+  0% {
+    transform: translateX(-60%);
+  }
+  50% {
+    transform: translateX(-10%);
+  }
+  100% {
+    transform: translateX(0%);
+  }
+}
+.progress .bar {
+  width: 85%;
+  transform: translateX(-60%);
+  animation: loadPulse 1.2s ease-in-out infinite alternate;
+}
+.progress.done .bar {
+  animation: none;
+  width: 100%;
+  transform: none;
+  transition: width 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- add localized loading splash with progress bar and auto-hide on readiness
- wire splash text to language toggle and readiness checks
- style splash banner with animated green bar

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` (fails: browsers unavailable)
- `curl -I http://localhost:4174/{/,app.js,assets/logo.svg,api/fetch}`


------
https://chatgpt.com/codex/tasks/task_e_68a81b9743088326af0a72ddc9ba4e89