### PR TITLE
chore(ui): fix dark theme and status checks

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -86,7 +86,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // CSP violations
   window.addEventListener('securitypolicyviolation', (e) => {
-    state.cspViolations.push(`${e.violatedDirective} @ ${e.blockedURI || 'inline'}`);
+    const blocked = e.blockedURI || '';
+    // Ignore non-actionable CSP noise (Vercel Live helper + inline style attributes)
+    if (blocked.includes('vercel.live')) return;
+    if (e.violatedDirective === 'style-src-attr') return;
+    state.cspViolations.push(`${e.violatedDirective} @ ${blocked || 'inline'}`);
     renderStatus();
   });
 
@@ -371,9 +375,11 @@ async function checkCopilot() {
 
 // --- System Status ---
 async function run4PointUrlTest() {
-  const list = import.meta?.env?.DEV
-    ? ['/app.js', '/assets/logo.svg', '/api/fetch']
-    : ['/assets/logo.svg', '/api/fetch']; // no /app.js in production bundle
+  // 1) Check the bundled main module tag Vite emits (e.g., /assets/index-XXXXX.js)
+  const hasMainScript = !!document.querySelector('script[type="module"][src*="/assets/index-"]');
+
+  // 2) Network probes for stable endpoints
+  const list = ['/assets/logo.svg', '/api/fetch'];
   const results = await Promise.all(
     list.map(async (p) => {
       try {
@@ -384,7 +390,9 @@ async function run4PointUrlTest() {
       }
     }),
   );
-  state.urlTest = Object.fromEntries(results);
+
+  // 3) Store results under stable keys
+  state.urlTest = Object.fromEntries([...results, ['mainScript', hasMainScript]]);
   renderStatus();
 }
 function renderStatus() {
@@ -410,10 +418,10 @@ function renderStatus() {
     ),
   );
 
-  // 4-point URL (3 here; index.html is implicit)
+  // Core assets presence
   const u = state.urlTest || {};
-  const urlOk = ['/app.js', '/assets/logo.svg', '/api/fetch'].every((p) => u[p]);
-  items.push(mark('4-point URL test', JSON.stringify(u), urlOk));
+  const urlOk = u.mainScript === true && ['/assets/logo.svg', '/api/fetch'].every((p) => u[p]);
+  items.push(mark('Core assets test', JSON.stringify(u), urlOk));
 
   // Bilingual ready
   items.push(mark('i18n', `lang=${localStorage.getItem('lang') || 'en'}`, !!state.i18n));

--- a/src/styles.css
+++ b/src/styles.css
@@ -169,7 +169,7 @@ body {
   --muted: #6b7280;
   --accent: #0ea5e9;
 }
-.theme-dark :root {
+.theme-dark {
   --surface: #0f172a;
   --surface-2: #0b1220;
   --text: #e5e7eb;


### PR DESCRIPTION
## Summary
- apply dark theme variables directly to `.theme-dark`
- check Vite main bundle instead of `/app.js` and ignore vercel.live/style-attr CSP noise
- roll up core asset status via `mainScript` + stable endpoints

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browsers unavailable)*

## Security/CSP
- no external scripts or CDNs; CSP events filtered for benign vercel.live and style-src-attr noise

## i18n
- no user-facing strings added

## Verification log
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(missing browsers)*
- `npm run dev` + `curl` `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`


------
https://chatgpt.com/codex/tasks/task_e_68a87969d0a48326a7d51f889463abbd