### PR TITLE
feat: add progress welcome overlay

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -35,5 +35,10 @@
   "Welcome": "Welcome to CST SmartDesk",
   "WelcomeIntro": "Faster serve/solve/sell with bilingual responses, carrier checks, and a secure workspace.",
   "Get Started": "Get Started",
-  "Dismiss": "Dismiss"
+  "Dismiss": "Dismiss",
+  "PleaseWait": "Please wait… loading",
+  "LoadingUI": "Loading user interface…",
+  "LoadingTranslations": "Loading translations…",
+  "CheckingCore": "Checking core assets…",
+  "StartingApp": "Starting app…"
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -35,5 +35,10 @@
   "Welcome": "Bienvenido a CST SmartDesk",
   "WelcomeIntro": "Atiende, resuelve y ofrece más rápido con respuestas bilingües, verificaciones de operadoras y un espacio de trabajo seguro.",
   "Get Started": "Comenzar",
-  "Dismiss": "Omitir"
+  "Dismiss": "Omitir",
+  "PleaseWait": "Por favor espera… cargando",
+  "LoadingUI": "Cargando la interfaz…",
+  "LoadingTranslations": "Cargando traducciones…",
+  "CheckingCore": "Verificando recursos básicos…",
+  "StartingApp": "Iniciando la aplicación…"
 }

--- a/src/app.js
+++ b/src/app.js
@@ -12,8 +12,9 @@ const state = {
   splashShown: false,
   lang: 'en',
 };
-let splashTimer = null;
-let splashProgress = 0;
+let splashMsgTimer = null;
+let splashAnimDone = false;
+let splashAssetsDone = false;
 
 // Ensure the Copilot select always has at least one option
 function ensureCopilotSeed(lang) {
@@ -43,10 +44,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   state.lang = lang;
   // localize static title immediately
   localizeStatic();
-  // splash: show on first visit, and wire buttons
+  // splash behavior: first visit auto; button to re-open
   const firstVisit = localStorage.getItem('welcomeSeen') !== '1';
   const btnShow = document.getElementById('showWelcome');
-  if (btnShow) btnShow.addEventListener('click', () => showSplash());
+  if (btnShow)
+    btnShow.addEventListener('click', () => {
+      showSplash();
+      setTimeout(() => localStorage.setItem('welcomeSeen', '1'), 800);
+    });
   const btnStart = document.getElementById('splashStart');
   if (btnStart)
     btnStart.addEventListener('click', () => {
@@ -136,16 +141,10 @@ function localizeStatic() {
     .forEach((el) => (el.placeholder = state.i18n.t(el.dataset.i18nPlaceholder)));
 }
 
-function startSplashProgress() {
-  const bar = document.getElementById('splashProgress');
-  if (!bar) return;
-  splashProgress = 0;
-  clearInterval(splashTimer);
-  splashTimer = setInterval(() => {
-    splashProgress = Math.min(100, splashProgress + (8 + Math.random() * 14));
-    bar.style.width = splashProgress + '%';
-    if (splashProgress >= 100) clearInterval(splashTimer);
-  }, 120);
+function setStep(textKey) {
+  const el = document.getElementById('splashStep');
+  if (!el) return;
+  el.textContent = state.i18n ? state.i18n.t(textKey) : textKey;
 }
 
 function showSplash() {
@@ -153,7 +152,22 @@ function showSplash() {
   if (!el) return;
   el.hidden = false;
   el.classList.add('show');
-  startSplashProgress();
+  const bar = document.getElementById('splashBar');
+  if (bar) {
+    bar.classList.remove('run');
+    requestAnimationFrame(() => bar.classList.add('run'));
+  }
+  const steps = ['LoadingUI', 'LoadingTranslations', 'CheckingCore', 'StartingApp'];
+  let idx = 0;
+  setStep(steps[idx]);
+  clearInterval(splashMsgTimer);
+  splashMsgTimer = setInterval(() => {
+    idx = Math.min(idx + 1, steps.length - 1);
+    setStep(steps[idx]);
+  }, 700);
+  splashAnimDone = false;
+  splashAssetsDone = false;
+  waitForSplashFinish();
 }
 
 function hideSplash() {
@@ -161,7 +175,33 @@ function hideSplash() {
   if (!el) return;
   el.classList.remove('show');
   el.hidden = true;
-  clearInterval(splashTimer);
+  clearInterval(splashMsgTimer);
+}
+
+function waitForSplashFinish() {
+  const bar = document.getElementById('splashBar');
+  if (bar) {
+    const onEnd = () => {
+      splashAnimDone = true;
+      maybeCloseSplash();
+    };
+    bar.addEventListener('animationend', onEnd, { once: true });
+    setTimeout(onEnd, 2600);
+  } else {
+    splashAnimDone = true;
+  }
+  Promise.allSettled([
+    fetch('/i18n/en.json', { cache: 'no-store' }),
+    fetch('/i18n/es.json', { cache: 'no-store' }),
+    fetch('/assets/logo.svg', { cache: 'no-store' }),
+  ]).then(() => {
+    splashAssetsDone = true;
+    maybeCloseSplash();
+  });
+}
+
+function maybeCloseSplash() {
+  if (splashAnimDone && splashAssetsDone) hideSplash();
 }
 
 // --- Setup Wizard ---
@@ -462,5 +502,5 @@ function escapeHtml(s) {
 }
 
 window.addEventListener('load', () => {
-  if (localStorage.getItem('welcomeSeen') !== '1') setTimeout(hideSplash, 700);
+  if (localStorage.getItem('welcomeSeen') !== '1') setTimeout(maybeCloseSplash, 400);
 });

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
     />
     <link rel="stylesheet" href="./styles/tokens.css" />
     <link rel="stylesheet" href="./styles.css" />
-    <!-- no inline styles/scripts: CSP-safe -->
+    <!-- CSP-safe: no inline styles or scripts -->
   </head>
   <body>
     <header class="topbar">
@@ -28,7 +28,7 @@
       </div>
     </header>
 
-    <!-- First-run splash (overlay) -->
+    <!-- Full-screen welcome / loader -->
     <section id="splash" class="banner overlay" role="dialog" aria-labelledby="splashTitle" hidden>
       <div class="banner-inner">
         <div class="banner-body">
@@ -37,9 +37,13 @@
             Faster serve/solve/sell with bilingual responses, carrier checks, and a secure
             workspace.
           </p>
+          <p id="splashNote" class="note" data-i18n="PleaseWait">Please wait…</p>
           <div class="progress" aria-hidden="true">
-            <div class="bar" id="splashProgress" style="width: 0%"></div>
+            <div class="bar" id="splashBar"></div>
           </div>
+          <ul class="steps" aria-live="polite" aria-atomic="true">
+            <li id="splashStep"></li>
+          </ul>
           <div class="banner-actions">
             <button id="splashStart" class="btn-primary" data-i18n="Get Started">
               Get Started

--- a/src/styles.css
+++ b/src/styles.css
@@ -124,17 +124,41 @@ body {
   font-size: 0.95rem;
 }
 .progress {
-  height: 10px;
+  height: 12px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.1);
   overflow: hidden;
-  margin: 12px 0 16px;
+  margin: 0.5rem 0 1rem;
 }
 .progress .bar {
+  width: 100%;
   height: 100%;
-  border-radius: 999px;
-  background: linear-gradient(90deg, #22d3ee, #818cf8, #a78bfa);
-  transition: width 0.18s ease;
+  transform-origin: left center;
+  transform: scaleX(0);
+  background: linear-gradient(90deg, #22c55e, #16a34a, #22c55e);
+  box-shadow: 0 0 12px rgba(34, 197, 94, 0.35);
+}
+@keyframes fill {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+.progress .bar.run {
+  animation: fill 2.4s ease-in-out forwards;
+}
+
+/* rotating step text under the bar */
+.steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem;
+}
+.steps li {
+  color: #a7b0bd;
+  min-height: 1.25rem;
 }
 
 /* Layout polish */
@@ -225,7 +249,7 @@ body {
   z-index: 1000;
   display: grid;
   place-items: center;
-  background: color-mix(in oklab, var(--bg, #0b1220) 85%, transparent);
+  background: color-mix(in oklab, var(--bg, #0b1220) 88%, transparent);
   backdrop-filter: blur(3px);
   opacity: 0;
   transition: opacity 0.25s ease;
@@ -234,22 +258,30 @@ body {
   opacity: 1;
 }
 #splash .banner-inner {
-  width: min(720px, 92vw);
-  border-radius: 16px;
-  padding: 24px;
+  width: min(760px, 94vw);
+  border-radius: 18px;
+  padding: 28px;
   background: var(--card, #0f172a);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.45);
+}
+#splash .banner-body > h2 {
+  margin: 0 0 0.4rem;
 }
 #splash .banner-body > p {
-  margin-block: 0.5rem 1rem;
+  margin: 0 0 0.75rem;
   color: var(--muted, #94a3b8);
+}
+#splash .note {
+  color: #9ca3af;
+  margin: 0.25rem 0 0.5rem;
 }
 
 /* Highlights hero placeholder (keeps your current look) */
 #highlights .highlights-hero {
   height: 180px;
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+  background: radial-gradient(60% 80% at 30% 30%, rgba(34, 197, 94, 0.25), transparent),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
   border: 1px dashed rgba(255, 255, 255, 0.12);
 }
 


### PR DESCRIPTION
## Summary
- add full-screen welcome overlay with animated progress and step hints
- wire splash lifecycle and asset preloading in JS
- localize new welcome/loader strings in en and es

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `curl -I http://localhost:4175/` (200)
- `curl -I http://localhost:4175/app.js` (200)
- `curl -I http://localhost:4175/assets/logo.svg` (200)
- `curl -I http://localhost:4175/api/fetch` (200)


------
https://chatgpt.com/codex/tasks/task_e_68a89d5e4f208326a7d658294b29b189