### PR TITLE
Add highlights list container

### DIFF
--- a/public/highlights.json
+++ b/public/highlights.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "outage-check",
+    "title": { "en": "Outage quick check", "es": "Chequeo rápido de averías" },
+    "body": {
+      "en": "Before you escalate, run a 30-second service check.",
+      "es": "Antes de escalar, realiza una verificación de servicio de 30 segundos."
+    }
+  },
+  {
+    "id": "billing-policy",
+    "title": { "en": "Billing policy refresher", "es": "Recordatorio de política de facturación" },
+    "body": {
+      "en": "Refunds require supervisor approval beyond 30 days.",
+      "es": "Reembolsos requieren aprobación del supervisor después de 30 días."
+    }
+  },
+  {
+    "id": "tone-template",
+    "title": { "en": "Tone template (EN/ES)", "es": "Plantilla de tono (EN/ES)" },
+    "body": {
+      "en": "Use the Serve/Solve/Sell starter prompt for tricky chats.",
+      "es": "Usa el prompt inicial Atender/Resolver/Ofrecer para casos difíciles."
+    }
+  }
+]

--- a/src/app.js
+++ b/src/app.js
@@ -128,6 +128,7 @@ async function toggleLang() {
   localizeStatic();
   renderCopilotUI();
   renderStatus();
+  loadHighlights();
 }
 
 function localizeStatic() {
@@ -504,3 +505,28 @@ function escapeHtml(s) {
 window.addEventListener('load', () => {
   if (localStorage.getItem('welcomeSeen') !== '1') setTimeout(maybeCloseSplash, 400);
 });
+
+// ---------- Highlights: render from public/highlights.json ----------
+async function loadHighlights() {
+  const host = document.getElementById('highlightsList');
+  if (!host) return;
+  try {
+    const list = await fetch('/highlights.json', { cache: 'no-store' }).then((r) =>
+      r.ok ? r.json() : [],
+    );
+    host.innerHTML = '';
+    list.forEach((item) => {
+      const card = document.createElement('article');
+      card.className = 'card';
+      const title = item.title?.[state.lang] || item.title?.en || '';
+      const body = item.body?.[state.lang] || item.body?.en || '';
+      card.innerHTML = `<h3>${escapeHtml(title)}</h3><p>${escapeHtml(body)}</p>`;
+      host.appendChild(card);
+    });
+  } catch {
+    // keep empty on error
+  }
+}
+
+// run on first load and when language toggles
+document.addEventListener('DOMContentLoaded', loadHighlights);

--- a/src/index.html
+++ b/src/index.html
@@ -57,6 +57,7 @@
     <section id="highlights" aria-labelledby="highlightsTitle">
       <h2 id="highlightsTitle" data-i18n="Highlights">Highlights</h2>
       <p data-i18n="HighlightsIntro">Top tips and updates for CST experts</p>
+      <div id="highlightsList" class="cards" aria-live="polite"></div>
       <div class="highlights-hero" role="img" aria-label="Highlights hero"></div>
     </section>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -285,6 +285,30 @@ body {
   border: 1px dashed rgba(255, 255, 255, 0.12);
 }
 
+/* Highlights cards */
+#highlights .cards {
+  margin-top: 1rem;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+#highlights .card {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: color-mix(in oklab, var(--card, #0f172a) 92%, transparent);
+}
+#highlights .card h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1.05rem;
+}
+#highlights .card p {
+  margin: 0;
+  color: var(--muted, #94a3b8);
+  line-height: 1.35;
+  font-size: 0.92rem;
+}
+
 .status {
   background: var(--surface);
   border: 1px solid rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
## Summary
- render highlights cards from a JSON feed and refresh on language changes
- seed `public/highlights.json` with bilingual sample entries

## Checks
- `npm run lint`
- `npm test`
- `npm run e2e:codex` *(fails: browsers unavailable)*
- `npm run dev` *(manual smoke: /, /app.js, /assets/logo.svg, /api/fetch)*

## Security/CSP
- no external scripts added; innerHTML content sanitized

## i18n
- highlights.json entries provide `{ en, es }`

## Verification Log
- `npm run lint`
- `npm test`
- `npm run e2e:codex` *(browsers missing)*
- `npm run dev` & curl `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`


------
https://chatgpt.com/codex/tasks/task_e_68a8a7e44b8c8326a0ee8c27a35faa9a