### PR TITLE
Add splash progress percentage and retry control

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -40,5 +40,6 @@
   "LoadingUI": "Loading user interface…",
   "LoadingTranslations": "Loading translations…",
   "CheckingCore": "Checking core assets…",
-  "StartingApp": "Starting app…"
+  "StartingApp": "Starting app…",
+  "Retry": "Retry"
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -40,5 +40,6 @@
   "LoadingUI": "Cargando la interfaz…",
   "LoadingTranslations": "Cargando traducciones…",
   "CheckingCore": "Verificando recursos básicos…",
-  "StartingApp": "Iniciando la aplicación…"
+  "StartingApp": "Iniciando la aplicación…",
+  "Retry": "Reintentar"
 }

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,8 @@ const state = {
 let splashMsgTimer = null;
 let splashAnimDone = false;
 let splashAssetsDone = false;
+let splashPct = 0;
+let splashPctTimer = null;
 
 // Ensure the Copilot select always has at least one option
 function ensureCopilotSeed(lang) {
@@ -158,6 +160,21 @@ function showSplash() {
     bar.classList.remove('run');
     requestAnimationFrame(() => bar.classList.add('run'));
   }
+  // % counter (smooth, capped until finish)
+  splashPct = 0;
+  updatePct();
+  clearInterval(splashPctTimer);
+  splashPctTimer = setInterval(() => {
+    splashPct = Math.min(splashPct + 7, 97);
+    updatePct();
+    if (splashPct >= 97) clearInterval(splashPctTimer);
+  }, 180);
+  const retry = document.getElementById('splashRetry');
+  if (retry)
+    retry.onclick = () => {
+      clearInterval(splashPctTimer);
+      showSplash();
+    };
   const steps = ['LoadingUI', 'LoadingTranslations', 'CheckingCore', 'StartingApp'];
   let idx = 0;
   setStep(steps[idx]);
@@ -170,6 +187,10 @@ function showSplash() {
   splashAssetsDone = false;
   waitForSplashFinish();
 }
+function updatePct() {
+  const el = document.getElementById('splashPct');
+  if (el) el.textContent = `${splashPct}%`;
+}
 
 function hideSplash() {
   const el = document.getElementById('splash');
@@ -177,6 +198,7 @@ function hideSplash() {
   el.classList.remove('show');
   el.hidden = true;
   clearInterval(splashMsgTimer);
+  clearInterval(splashPctTimer);
 }
 
 function waitForSplashFinish() {
@@ -202,7 +224,11 @@ function waitForSplashFinish() {
 }
 
 function maybeCloseSplash() {
-  if (splashAnimDone && splashAssetsDone) hideSplash();
+  if (splashAnimDone && splashAssetsDone) {
+    splashPct = 100;
+    updatePct();
+    hideSplash();
+  }
 }
 
 // --- Setup Wizard ---

--- a/src/index.html
+++ b/src/index.html
@@ -41,6 +41,7 @@
           <div class="progress" aria-hidden="true">
             <div class="bar" id="splashBar"></div>
           </div>
+          <div class="pct-row"><span id="splashPct">0%</span></div>
           <ul class="steps" aria-live="polite" aria-atomic="true">
             <li id="splashStep"></li>
           </ul>
@@ -48,6 +49,7 @@
             <button id="splashStart" class="btn-primary" data-i18n="Get Started">
               Get Started
             </button>
+            <button id="splashRetry" class="btn-quiet" data-i18n="Retry">Retry</button>
             <button id="splashDismiss" class="btn-quiet" data-i18n="Dismiss">Dismiss</button>
           </div>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -160,6 +160,22 @@ body {
   color: #a7b0bd;
   min-height: 1.25rem;
 }
+.pct-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: -0.5rem;
+  margin-bottom: 0.25rem;
+}
+#splashPct {
+  color: #a7b0bd;
+  font-variant-numeric: tabular-nums;
+}
+@media (prefers-reduced-motion: reduce) {
+  .progress .bar.run {
+    animation: none;
+    transform: scaleX(1);
+  }
+}
 
 /* Layout polish */
 :root {


### PR DESCRIPTION
## Summary
- show loader progress percent with a smooth counter
- provide Retry button to restart splash checks
- localize new Retry label in English and Spanish

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1129/chrome-linux/chrome)*
- `npm run dev` + curl `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`

## Security/CSP
- No external scripts added; CSP remains satisfied

## i18n
- `Retry`

## Verification Log
- `npm run lint`
- `npm run test`
- `npm run e2e:codex`
- `npm run dev` (curl 4 endpoints)

------
https://chatgpt.com/codex/tasks/task_e_68a8ad21c2f88326a5afe357b1bdddc1