### PR TITLE
Add skip link and splash focus trap for accessibility

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ let splashAnimDone = false;
 let splashAssetsDone = false;
 let splashPct = 0;
 let splashPctTimer = null;
+let splashKeyHandler = null;
 
 // Ensure the Copilot select always has at least one option
 function ensureCopilotSeed(lang) {
@@ -160,6 +161,31 @@ function showSplash() {
     bar.classList.remove('run');
     requestAnimationFrame(() => bar.classList.add('run'));
   }
+  // focus trap & Esc to close after first visit
+  const container = document.getElementById('splash');
+  const panel = container?.querySelector('.banner-inner');
+  if (panel) {
+    panel.setAttribute('tabindex', '-1');
+    panel.focus();
+  }
+  splashKeyHandler = (e) => {
+    if (e.key === 'Escape' && localStorage.getItem('welcomeSeen') === '1') hideSplash();
+    if (e.key !== 'Tab') return;
+    const F = "a[href],button,textarea,input,select,[tabindex]:not([tabindex='-1'])";
+    const nodes = [...container.querySelectorAll(F)].filter((el) => !el.disabled);
+    if (!nodes.length) return;
+    const first = nodes[0],
+      last = nodes[nodes.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      last.focus();
+      e.preventDefault();
+    }
+    if (!e.shiftKey && document.activeElement === last) {
+      first.focus();
+      e.preventDefault();
+    }
+  };
+  container.addEventListener('keydown', splashKeyHandler);
   // % counter (smooth, capped until finish)
   splashPct = 0;
   updatePct();
@@ -199,6 +225,8 @@ function hideSplash() {
   el.hidden = true;
   clearInterval(splashMsgTimer);
   clearInterval(splashPctTimer);
+  el.removeEventListener('keydown', splashKeyHandler);
+  splashKeyHandler = null;
 }
 
 function waitForSplashFinish() {

--- a/src/index.html
+++ b/src/index.html
@@ -18,6 +18,7 @@
     <!-- CSP-safe: no inline styles or scripts -->
   </head>
   <body>
+    <a href="#mainContent" class="skip" data-i18n="Skip to content">Skip to content</a>
     <header class="topbar">
       <h1 id="appTitle">CST SmartDesk</h1>
       <div class="top-actions">
@@ -71,7 +72,7 @@
       </div>
     </aside>
 
-    <main class="content">
+    <main id="mainContent" class="content">
       <section class="dropzone" id="dropzone" aria-label="Drag & drop files">
         <p id="dzText">Drop PDF/TXT here or paste text (Ctrl+V).</p>
         <pre id="preview" class="preview"></pre>

--- a/src/public/i18n/en.json
+++ b/src/public/i18n/en.json
@@ -36,6 +36,7 @@
   "WelcomeIntro": "Faster serve/solve/sell with bilingual responses, carrier checks, and a secure workspace.",
   "Get Started": "Get Started",
   "Dismiss": "Dismiss",
+  "Skip to content": "Skip to content",
   "LoadingSplash": "Loading CST SmartDesk — stand by…",
   "Ready": "Ready"
 }

--- a/src/public/i18n/es.json
+++ b/src/public/i18n/es.json
@@ -36,6 +36,7 @@
   "WelcomeIntro": "Sirve/resuelve/vende más rápido con respuestas bilingües, verificaciones de operadores y un espacio de trabajo seguro.",
   "Get Started": "Comenzar",
   "Dismiss": "Descartar",
+  "Skip to content": "Saltar al contenido",
   "LoadingSplash": "Cargando CST SmartDesk — espere…",
   "Ready": "Listo"
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,25 @@
 /* --- Layout / Theme polish --- */
+
+/* Skip link (a11y) */
+.skip {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.skip:focus {
+  left: 12px;
+  top: 12px;
+  width: auto;
+  height: auto;
+  padding: 8px 12px;
+  background: #fff;
+  color: #111;
+  border-radius: 10px;
+  z-index: 1100;
+}
 :root {
   --page-bg: #f6f8fb;
   --card-bg: #ffffff;


### PR DESCRIPTION
## Summary
- add bilingual skip link to jump to main content
- trap focus and support Esc on welcome splash screen
- style skip link for visibility when focused

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: browsers unavailable, see log)*

## Security/CSP
- no external scripts added; existing CSP remains intact

## i18n
- added `Skip to content` in `en.json` and `es.json`

## Verification log
- `npm run lint`
- `npm run test`
- `npm run e2e:codex`
- `npm run dev` (curl `/`, `/app.js`, `/assets/logo.svg`, `/api/fetch`)


------
https://chatgpt.com/codex/tasks/task_e_68a8b099606c8326b76051dd93f2fa6a