### PR TITLE
feat: add support highlights

### DIFF
--- a/public/highlights.json
+++ b/public/highlights.json
@@ -22,5 +22,29 @@
       "en": "Use the Serve/Solve/Sell starter prompt for tricky chats.",
       "es": "Usa el prompt inicial Atender/Resolver/Ofrecer para casos difíciles."
     }
+  },
+  {
+    "id": "billing-checks",
+    "title": { "en": "Billing checks to do first", "es": "Revisiones de facturación" },
+    "body": {
+      "en": "Verify plan, promos, credits and past-due before escalation.",
+      "es": "Verifique plan, promociones, créditos y morosidad antes de escalar."
+    }
+  },
+  {
+    "id": "porting-tips",
+    "title": { "en": "Number porting tips", "es": "Consejos para portar número" },
+    "body": {
+      "en": "Confirm account number, PIN and billing ZIP. Warn about downtime.",
+      "es": "Confirme número de cuenta, PIN y código postal. Avise sobre interrupciones."
+    }
+  },
+  {
+    "id": "fraud-reminder",
+    "title": { "en": "Fraud guardrails", "es": "Guardas contra fraude" },
+    "body": {
+      "en": "Never request full SSN or full card over chat. Use masked inputs.",
+      "es": "Nunca solicite SSN completo ni tarjeta completa por chat. Use datos enmascarados."
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- expand highlights with billing checks, porting tips, and fraud guardrails

## Checks
- `npm run lint`
- `npm run test`
- `npm run e2e:codex` *(fails: missing browser executables)*
- `node scripts/dev-server.mjs` & curl `localhost:4173/{/,app.js,assets/logo.svg,api/fetch}`


------
https://chatgpt.com/codex/tasks/task_e_68a8bab9a1f0832694472e9325d786c5